### PR TITLE
OSX compatability - reboot() already defined and a conflict exists.

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -320,7 +320,7 @@ static void mavlink_message_send(struct template_state *tmpl, const char *name, 
 static void reboot_companion(struct template_state *tmpl, const char *name, const char *value, int argc, char **argv)
 {
     console_printf("rebooting ...\n");
-    reboot();    
+    __reboot();    
 }
 
 extern void snx_nvram_bootup_upgrade(void);

--- a/linux/util_linux.c
+++ b/linux/util_linux.c
@@ -65,9 +65,14 @@ bool toggle_recording(void)
     return false;
 }
 
-void reboot(void)
+void __reboot(void)
 {
-    printf("reboot not implemented\n");
+    #if __APPLE__
+        printf("reboot OSX implemented, but disabled for now.\n");
+        //reboot(0);
+    #else
+        printf("reboot not implemented\n");
+    #endif
 }
 
 

--- a/linux/util_linux.h
+++ b/linux/util_linux.h
@@ -20,8 +20,8 @@ uint32_t get_time_boot_ms();
 void mdelay(uint32_t ms);
 
 bool toggle_recording(void);
-void reboot(void);
 
+void __reboot(void); // __ so we don't call the os version of this by mistake.
 
 char *print_vprintf(void *ctx, const char *fmt, va_list ap);
 void *print_printf(void *ctx, const char *fmt, ...);


### PR DESCRIPTION
osx defines the reboot function as int reboot(int) which is incompatible with the void reboot(void) used here, so I rename the local one to __reboot.